### PR TITLE
Upping memory allocation for lambda

### DIFF
--- a/aws-iotcoredeviceadvisor-suitedefinition/template.yml
+++ b/aws-iotcoredeviceadvisor-suitedefinition/template.yml
@@ -5,7 +5,7 @@ Description: AWS SAM template for the AWS::IoTCoreDeviceAdvisor::SuiteDefinition
 Globals:
   Function:
     Timeout: 180  # docker start-up times can be long for SAM CLI
-    MemorySize: 512 
+    MemorySize: 512
 
 Resources:
   TypeFunction:


### PR DESCRIPTION
Upping lambda allocated memory since I was sporadically seeing memory issues, no issues seen since this value was increased. 
